### PR TITLE
Address issue #2: improperly ordered receipts

### DIFF
--- a/signing_service/receipts/tests/test_views.py
+++ b/signing_service/receipts/tests/test_views.py
@@ -59,5 +59,5 @@ class ReceiptsViewTest(TestCase):
                    "verify": "https://appstore.com/verify/5169314356"}
         request = self.factory.post('/1.0/sign', receipt, format='json')
         response = self.view(request)
-        signed_receipt, certificate = response.data['receipt'].split('~')
+        certificate, signed_receipt = response.data['receipt'].split('~')
         self.assertEqual(receipt, jwt.decode(signed_receipt, verify=False))

--- a/signing_service/receipts/views.py
+++ b/signing_service/receipts/views.py
@@ -50,5 +50,5 @@ class ReceiptsView(APIView):
         # to JSON before signing.
         signed_jwt = _SIGNER.sign(receipt)
 
-        return Response({'receipt': '~'.join((signed_jwt,
-                                              _SIGNER.certificate))})
+        return Response({'receipt': '~'.join((_SIGNER.certificate,
+                                              signed_jwt))})


### PR DESCRIPTION
I managed to reverse the order of the receipts when I converted the logic here
from the old trunion source tree.  Remedy that.

r? @andymckay
